### PR TITLE
Fix filenames to work as documented in pdf_convert()

### DIFF
--- a/R/render.R
+++ b/R/render.R
@@ -73,9 +73,13 @@ pdf_convert <- function(pdf, format = "png", pages = NULL, filenames = NULL , dp
     pages <- seq_len(pdf_info(pdf, opw = opw, upw = upw)$pages)
   if(!is.numeric(pages) || !length(pages))
     stop("Argument 'pages' must be a one-indexed vector of page numbers")
-  if(!length(filenames)){
+  if(length(filenames) < 2){
     input <- sub(".pdf", "", basename(pdf), fixed = TRUE)
-    filenames <- sprintf("%s_%d.%s", input, pages, format)
+    filenames <- if (length(filenames)) {
+      sprintf(filenames, pages, format)
+    } else {
+      sprintf("%s_%d.%s", input, pages, format)
+    }
   }
   if(length(filenames) != length(pages))
     stop("Length of 'filenames' must be one or equal to 'pages'")

--- a/tests/testthat/test-render.R
+++ b/tests/testthat/test-render.R
@@ -9,4 +9,13 @@ test_that("rendering pdf", {
   expect_equal(pdf_convert("pdf-example-password.original.pdf", upw = "test", verbose = FALSE), outfiles)
   expect_true(all(file.exists(outfiles)))
   unlink(outfiles)
+
+  # Use filenames format string
+  outfiles <- paste0("test_0", 1:4, ".png")
+  expect_equal(
+    pdf_convert("pdf-example-password.original.pdf", upw = "test", verbose = FALSE, filenames = "test_%02d.%s"),
+    outfiles
+  )
+  expect_true(all(file.exists(outfiles)))
+  unlink(outfiles)
 })


### PR DESCRIPTION
The documentation for `filenames` in `pdf_convert()` reads

> `filenames` vector of equal length to `pages` with output filenames. May also be a format string which is expanded using `pages` and `format` respectively.

but the current implementation expects `filenames` to have the same length as `pages` or be length zero to receive the default, meaning that passing `filenames = "my_doc_%d.%s"` throws an error instead of expanding the format string using `pages` and `format`.

This PR modifies `pdf_convert()` to work as documented and adds an additional test.