### PR TITLE
Use `poppler` in SystemRequirements

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,8 +12,7 @@ URL: https://docs.ropensci.org/pdftools (website)
     https://github.com/ropensci/pdftools#readme (devel)
     https://poppler.freedesktop.org (upstream)
 BugReports: https://github.com/ropensci/pdftools/issues
-SystemRequirements: Poppler C++ API: libpoppler-cpp-dev (deb) or poppler-cpp-devel (rpm).
-    The unit tests also require the 'poppler-data' package (rpm/deb)
+SystemRequirements: poppler, the unit tests also require the 'poppler-data' package (rpm/deb)
 Encoding: UTF-8
 Imports: 
     Rcpp (>= 0.12.12),


### PR DESCRIPTION
Should trigger https://github.com/rstudio/r-system-requirements/blob/af9231b2b29caceaeff14fa7cff80d1e8f9d36cb/rules/poppler.json

(untested)