### PR TITLE
Typo in the code

### DIFF
--- a/R/tools.R
+++ b/R/tools.R
@@ -60,7 +60,7 @@ pdf_data <- function(pdf, font_info = FALSE, opw = "", upw = "") {
 #' @export
 pdf_fonts<- function(pdf, opw = "", upw = "") {
   out <- poppler_pdf_fonts(loadfile(pdf), opw, upw)
-  df_as_tibble(out)
+  as_tibble(out)
 }
 
 #' @rdname pdftools


### PR DESCRIPTION
Cf https://github.com/ropensci/pdftools/issues/88

Repairs the local font information. But I am not sure as_tibble is required anyway, commenting it gave me also a tibble.