### PR TITLE
add ability to pass options to the tesseract function

### DIFF
--- a/R/ocr.R
+++ b/R/ocr.R
@@ -7,11 +7,14 @@
 #' @family pdftools
 #' @inheritParams pdftools
 #' @param language passed to [tesseract][tesseract::tesseract] to specify the
-#' languge of the engine.
+#' language of the engine.
+#' @param options passed to [tesseract][tesseract::tesseract] to specify the
+#' options of the engine, must be a list. See [tesseract][tesseract::tesseract_params]
+#'  for possible inputs.
 #' @param pages which pages of the pdf file to extract
 #' @param dpi resolution to render image that is passed to [tesseract::ocr].
-pdf_ocr_text <- function(pdf, pages = NULL, opw = "", upw = "", language = "eng", dpi = 600){
-  engine <- tesseract::tesseract(language)
+pdf_ocr_text <- function(pdf, pages = NULL, opw = "", upw = "", dpi = 600, language = "eng", options = list()){
+  engine <- tesseract::tesseract(language = language, options = options)
   images <- pdf_convert(pdf = pdf, pages = pages, opw = opw, upw = upw, dpi = dpi)
   on.exit(unlink(images))
   vapply(images, tesseract::ocr, character(1), engine = engine, USE.NAMES = FALSE)
@@ -19,8 +22,17 @@ pdf_ocr_text <- function(pdf, pages = NULL, opw = "", upw = "", language = "eng"
 
 #' @export
 #' @rdname pdf_ocr
-pdf_ocr_data <- function(pdf, pages = NULL, opw = "", upw = "", language = "eng", dpi = 600){
-  engine <- tesseract::tesseract(language)
+pdf_ocr_text_2 <- function(pdf, pages = NULL, opw = "", upw = "", dpi = 600, language = "eng", options = list(tessedit_pageseg_mode = 1)){
+  engine <- tesseract::tesseract(language = language, options = options)
+  images <- pdf_convert(pdf = pdf, pages = pages, opw = opw, upw = upw, dpi = dpi)
+  on.exit(unlink(images))
+  vapply(images, tesseract::ocr, character(1), engine = engine, USE.NAMES = FALSE)
+}
+
+#' @export
+#' @rdname pdf_ocr
+pdf_ocr_data <- function(pdf, pages = NULL, opw = "", upw = "", dpi = 600, language = "eng", options = list()){
+  engine <- tesseract::tesseract(language = language, options = options)
   images <- pdf_convert(pdf = pdf, pages = pages, opw = opw, upw = upw, dpi = dpi)
   on.exit(unlink(images))
   lapply(images, tesseract::ocr_data, engine = engine)


### PR DESCRIPTION
I included the possibility to pass options to the tesseract function.
As discussed in issue #121 , this is important because it is impossible to import pdf documents with multiple columns using the pdf_ocr_text() function at the moment.
The pdf_ocr_text_2() function by default assumes the pdf to have multiple columns, but works perfectly with one column as well. 