### PR TITLE
Windows: use poppler from Rtools if found

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -18,7 +18,8 @@ jobs:
         config:
           - {os: macOS-latest,    r: 'release'}
           - {os: windows-latest,  r: 'devel'}
-          - {os: windows-latest,  r: 'release'}
+          - {os: windows-latest,  r: '4.4'}
+          - {os: windows-latest,  r: '4.3'}
           - {os: windows-latest,  r: '4.2'}
           - {os: windows-latest,  r: '4.1'}
           - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: pdftools
 Type: Package
 Title: Text Extraction, Rendering and Converting of PDF Documents
-Version: 3.4.1
+Version: 3.5.0
 Authors@R: person("Jeroen", "Ooms", role = c("aut", "cre"), email = "jeroenooms@gmail.com",
       comment = c(ORCID = "0000-0002-4035-0289"))
 Description: Utilities based on 'libpoppler' <https://poppler.freedesktop.org> for extracting

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,6 @@
+3.5.0
+  - Windows: use poppler from Rtools if found
+
 3.4.1
   - Remove some test verbosity as per CRAN requeset
   - Update maintainer email address

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,4 +1,4 @@
-PKG_CONFIG_NAME = poppler-cpp
+PKG_CONFIG_NAME = poppler-cpp poppler-data
 PKG_CONFIG ?= $(BINPREF)pkg-config
 PKG_CXXFLAGS = -Dpoppler_cpp_EXPORTS -DBUNDLE_POPPLER_DATA -DSTRICT_R_HEADERS -DR_NO_REMAP
 PKG_LIBS := $(shell $(PKG_CONFIG) --libs $(PKG_CONFIG_NAME))
@@ -6,7 +6,7 @@ PKG_LIBS := $(shell $(PKG_CONFIG) --libs $(PKG_CONFIG_NAME))
 ifneq ($(PKG_LIBS),)
 $(info using $(PKG_CONFIG_NAME) from Rtools)
 PKG_CPPFLAGS := $(shell $(PKG_CONFIG) --cflags $(PKG_CONFIG_NAME))
-POPPLERDATA := $(shell pkg-config --variable=poppler_datadir poppler-data)
+POPPLERDATA := $(shell pkg-config --variable=poppler_datadir $(PKG_CONFIG_NAME))
 else
 RWINLIB = ../windows/poppler
 PKG_CPPFLAGS = -I$(RWINLIB)/include/poppler/cpp -I$(RWINLIB)/include/poppler
@@ -28,5 +28,3 @@ copydata:
 
 clean:
 	rm -f $(SHLIB) $(OBJECTS)
-
-

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,24 +1,32 @@
-POPPLERDATA=share/poppler
-RWINLIB=../windows/poppler
-PKG_CXXFLAGS=-Dpoppler_cpp_EXPORTS -DBUNDLE_POPPLER_DATA
-PKG_CPPFLAGS=-I$(RWINLIB)/include/poppler/cpp \
-	-I$(RWINLIB)/include/poppler \
-	-DSTRICT_R_HEADERS -DR_NO_REMAP
+PKG_CONFIG_NAME = poppler-cpp
+PKG_CONFIG ?= $(BINPREF)pkg-config
+PKG_CXXFLAGS = -Dpoppler_cpp_EXPORTS -DBUNDLE_POPPLER_DATA -DSTRICT_R_HEADERS -DR_NO_REMAP
+PKG_LIBS := $(shell $(PKG_CONFIG) --libs $(PKG_CONFIG_NAME))
 
-PKG_LIBS= \
-	-L$(RWINLIB)/lib${subst gcc,,${COMPILED_BY}}${R_ARCH} \
-	-L$(RWINLIB)/lib \
-	-lpoppler-cpp -lpoppler -llcms2 -ljpeg -lpng16 -ltiff -lopenjp2 \
-	-lfreetype -lfreetype -lbz2 -liconv -lz
+ifneq ($(PKG_LIBS),)
+$(info using $(PKG_CONFIG_NAME) from Rtools)
+PKG_CPPFLAGS := $(shell $(PKG_CONFIG) --cflags $(PKG_CONFIG_NAME))
+POPPLERDATA := $(shell pkg-config --variable=poppler_datadir poppler-data)
+else
+RWINLIB = ../windows/poppler
+PKG_CPPFLAGS = -I$(RWINLIB)/include/poppler/cpp -I$(RWINLIB)/include/poppler
+PKG_LIBS = -L$(RWINLIB)/lib${subst gcc,,${COMPILED_BY}}${R_ARCH} -L$(RWINLIB)/lib \
+	-lpoppler-cpp -lpoppler -llcms2 -ljpeg -lpng16 -ltiff -lopenjp2 -lfreetype -lfreetype -lbz2 -liconv -lz
+POPPLERDATA = $(RWINLIB)/share/poppler
+endif
 
-all: clean winlibs
+all: $(SHLIB) copydata
+
+$(OBJECTS): $(RWINLIB)
+
+$(RWINLIB):
+	"${R_HOME}/bin${R_ARCH_BIN}/Rscript.exe" "../tools/winlibs.R"
+
+copydata:
+	rm -Rf ../inst/share && mkdir -p ../inst/share
+	cp -Rf $(POPPLERDATA) ../inst/share/
 
 clean:
-	rm -f $(OBJECTS) $(SHLIB)
+	rm -f $(SHLIB) $(OBJECTS)
 
-winlibs:
-	"${R_HOME}/bin${R_ARCH_BIN}/Rscript.exe" "../tools/winlibs.R"
-	rm -Rf ../inst/share && mkdir -p ../inst/share
-	cp -Rf $(RWINLIB)/$(POPPLERDATA) ../inst/share/poppler
 
-.PHONY: all winlibs clean


### PR DESCRIPTION
This only works in R 4.5 and up because poppler-data is missing in rtools44.