### PR TITLE
pdf_toc: Now returns if bookmarks are open

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,6 @@
+development
+  - pdf_toc() now also returns if bookmarks are open (#117)
+
 3.7.0
   - Switch some deprecated fields to new ones
 

--- a/src/bindings.cpp
+++ b/src/bindings.cpp
@@ -81,6 +81,7 @@ static List item_to_list(toc_item *item){
   }
   return List::create(
     _["title"] = ustring_to_r(item->title()),
+    _["is_open"] = item->is_open(),
     _["children"] = out
   );
 }


### PR DESCRIPTION
closes #117

Claude Code claims (w.r.t. to the bookmarks are open field):

> That's the only additional field the Poppler C++ public API exposes — page number, color, and font style would require accessing Poppler's internal OutlineItem API, which is beyond the public C++ bindings.   